### PR TITLE
Fix for json avc profile

### DIFF
--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -668,13 +668,12 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_L(",\"codec\":\"");
                         NGX_RTMP_STAT_ECS(cname);
                     }
-                    
+
                     if (codec->avc_profile) {
                         NGX_RTMP_STAT_L("\",\"profile\":\"");
                         NGX_RTMP_STAT_CS(
                                 ngx_rtmp_stat_get_avc_profile(codec->avc_profile));
-                    } else {
-                         NGX_RTMP_STAT_L("\"");
+                        NGX_RTMP_STAT_L("\"");
                     }
                     if (codec->avc_compat) {
                         NGX_RTMP_STAT_L("\",\"compat\":");
@@ -682,7 +681,7 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                                       "%ui", codec->avc_compat) - buf);
                     }
                     if (codec->avc_level) {
-                        NGX_RTMP_STAT_L(",\"level\":");
+                        NGX_RTMP_STAT_L("\",\"level\":");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
                     }

--- a/ngx_rtmp_stat_module.c
+++ b/ngx_rtmp_stat_module.c
@@ -673,18 +673,18 @@ ngx_rtmp_stat_live(ngx_http_request_t *r, ngx_chain_t ***lll,
                         NGX_RTMP_STAT_L("\",\"profile\":\"");
                         NGX_RTMP_STAT_CS(
                                 ngx_rtmp_stat_get_avc_profile(codec->avc_profile));
-                        NGX_RTMP_STAT_L("\"");
                     }
                     if (codec->avc_compat) {
-                        NGX_RTMP_STAT_L("\",\"compat\":");
+                        NGX_RTMP_STAT_L("\",\"compat\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%ui", codec->avc_compat) - buf);
                     }
                     if (codec->avc_level) {
-                        NGX_RTMP_STAT_L("\",\"level\":");
+                        NGX_RTMP_STAT_L("\",\"level\":\"");
                         NGX_RTMP_STAT(buf, ngx_snprintf(buf, sizeof(buf),
                                       "%.1f", codec->avc_level / 10.) - buf);
                     }
+                    NGX_RTMP_STAT_L("\"");
 
 
                     NGX_RTMP_STAT_L("}, \"audio\": {");


### PR DESCRIPTION
I believe this is the actual fix you wanted. I ran into an issue using your repo where I was getting

```
"video":{"width":1280,"height":720,"frame_rate":30,"codec":"H264","profile":"High,"level":3.1}
```

Notice the profile lacking the closing quote. I fixed this by adding the closing quote to the level before the comma. You can tell it was lacking as all of the other attributes do the same thing.
